### PR TITLE
feat: add states to equip able light-sources

### DIFF
--- a/Assets/Prefabs/LanternLight_01.prefab
+++ b/Assets/Prefabs/LanternLight_01.prefab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c6c6a2ad1f6bd4a05949f250d23e76619bea6b75ea00e27a478a51bbf9412ae
+size 4183

--- a/Assets/Prefabs/LanternLight_01.prefab.meta
+++ b/Assets/Prefabs/LanternLight_01.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 949c5083aca048845a1fa3a98709b246
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/TorchLight_01.prefab
+++ b/Assets/Prefabs/TorchLight_01.prefab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89b51ccaf79b66fc45cf7c14f31d1bc6f608ac0e3bb7af93ceff820126d9be64
+size 4167

--- a/Assets/Prefabs/TorchLight_01.prefab.meta
+++ b/Assets/Prefabs/TorchLight_01.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ff8c5c4fc7daabc4d8aa9daec3a10cd1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Test Room.unity
+++ b/Assets/Scenes/Test Room.unity
@@ -6437,6 +6437,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8c0ca496efa147641b0e9623a76f915f, type: 3}
+--- !u!1 &1518936350 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7728530816026570850, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
+  m_PrefabInstance: {fileID: 2142788100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1518936351
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1518936350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a53a1daa38fefc9478aa2e3272f69d01, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Battery: 0.8
 --- !u!1001 &1527090872
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Gameplay/Equipables.meta
+++ b/Assets/Scripts/Gameplay/Equipables.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4a87dea324409cc42abbe32fe66d409b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Equipables/LightingStateContext.cs
+++ b/Assets/Scripts/Gameplay/Equipables/LightingStateContext.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace ProjectWendigo
+{
+    public class LightingStateContext : AStateContext
+    {
+        [Range(0f, 1f)] public float Battery = 0.8f;
+
+        public void Start()
+        {
+            this.SetState(new LightingStates.Flickering());
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Equipables/LightingStateContext.cs.meta
+++ b/Assets/Scripts/Gameplay/Equipables/LightingStateContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a53a1daa38fefc9478aa2e3272f69d01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Equipables/LightingStates.meta
+++ b/Assets/Scripts/Gameplay/Equipables/LightingStates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5cb37b1f4a16260418c3dce56a926948
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Equipables/LightingStates/Flickering.cs
+++ b/Assets/Scripts/Gameplay/Equipables/LightingStates/Flickering.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using System.Collections;
+
+namespace ProjectWendigo.LightingStates
+{
+    public class Flickering : AState<LightingStateContext>
+    {
+        private float _timer;
+
+        public override void Enter()
+        {
+            GenerateTimer();
+        }
+
+        public override void Update()
+        {
+            if (_timer > 0)
+            {
+                _timer -= Time.deltaTime;
+            }
+            else
+            {
+                this.context.GetComponent<Light>().enabled = !this.context.GetComponent<Light>().enabled;
+                GenerateTimer();
+            }
+        }
+
+        private void GenerateTimer()
+        {
+            _timer = Random.Range(0.01f, Mathf.Abs(this.context.Battery - System.Convert.ToInt32(!this.context.GetComponent<Light>().enabled)));
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Equipables/LightingStates/Flickering.cs.meta
+++ b/Assets/Scripts/Gameplay/Equipables/LightingStates/Flickering.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6919b6415d9f3c64182d888ba4e18aa9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Equipables/LightingStates/Off.cs
+++ b/Assets/Scripts/Gameplay/Equipables/LightingStates/Off.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace ProjectWendigo.LightingStates
+{
+    public class Off : AState<LightingStateContext>
+    {
+        public override void Update()
+        {
+            this.context.GetComponent<Light>().enabled =  false;
+
+            if (Singletons.Main.Input.LightingToggled)
+            {
+                this.context.SetState(new On());
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Equipables/LightingStates/Off.cs.meta
+++ b/Assets/Scripts/Gameplay/Equipables/LightingStates/Off.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e45fb98874708f4c99239be3af1a401
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Equipables/LightingStates/On.cs
+++ b/Assets/Scripts/Gameplay/Equipables/LightingStates/On.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace ProjectWendigo.LightingStates
+{
+    public class On : AState<LightingStateContext>
+    {
+        public override void Update()
+        {
+            this.context.GetComponent<Light>().enabled =  true;
+
+            if (Singletons.Main.Input.LightingToggled)
+            {
+                this.context.SetState(new Off());
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Equipables/LightingStates/On.cs.meta
+++ b/Assets/Scripts/Gameplay/Equipables/LightingStates/On.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bccb43f2e96d604b9fa044378582282
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Inputs/PlayerControls.inputactions
+++ b/Assets/Scripts/Inputs/PlayerControls.inputactions
@@ -847,6 +847,34 @@
                     "isPartOfComposite": false
                 }
             ]
+        },
+        {
+            "name": "Lighting",
+            "id": "25260999-36e2-4e89-9287-6de71bedeced",
+            "actions": [
+                {
+                    "name": "Toggle light",
+                    "type": "Button",
+                    "id": "7c18b043-3fbb-4bd8-b293-97dd5c4a392c",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "0e274ee4-1be2-4925-992e-1b42f0df7539",
+                    "path": "<Keyboard>/p",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Toggle light",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
         }
     ],
     "controlSchemes": [

--- a/Assets/Scripts/Singletons/InputManager.cs
+++ b/Assets/Scripts/Singletons/InputManager.cs
@@ -10,7 +10,7 @@ namespace ProjectWendigo
         // General helpers
         public Vector2 MousePosition => Mouse.current.position.ReadValue();
 
-        // Player inputs helpers.
+        // Player inputs helpers
         public bool PlayerIsCrouching => this._playerInput.actions["Crouch"].IsPressed();
         public bool PlayerIsMoving => this.PlayerMovement != Vector2.zero;
         public bool PlayerJumped => this._playerInput.actions["Jump"].WasPressedThisFrame();
@@ -25,6 +25,9 @@ namespace ProjectWendigo
         public Vector2 PlayerLook => this._playerInput.actions["Look"].ReadValue<Vector2>();
         public Vector2 PlayerMovement => this._playerInput.actions["Move"].ReadValue<Vector2>();
 
+        // Lighting input helpers
+        public bool LightingToggled => this._playerInput.actions["Toggle light"].WasPressedThisFrame();
+        
         public void HideCursor()
         {
             Cursor.lockState = CursorLockMode.Locked;
@@ -40,6 +43,9 @@ namespace ProjectWendigo
         protected void Awake()
         {
             this._playerInput = this.GetComponent<PlayerInput>();
+            this._playerInput.actions.FindActionMap("Player").Enable();
+            this._playerInput.actions.FindActionMap("UI").Enable();
+            this._playerInput.actions.FindActionMap("Lighting").Enable();
 
             this.HideCursor();
         }


### PR DESCRIPTION
Implemented a state machine for equip able light sources, and added the following working states:

- On (Toggle `P`)
- Off (Toggle `P`)
- Flickering

When flickering, the light source will flicker in random intervals. It is affected by the `Battery` variable; a higher battery percentage means less off-time in between the flickering, and a lower battery means a higher off-time in between the flickering. The value of `Battery` must be between 0 and 1.