### PR TITLE
feat: sound manager and spatial sound

### DIFF
--- a/Assets/Prefabs/Singletons.prefab
+++ b/Assets/Prefabs/Singletons.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5e21a955fcef01be8fefddf7f37b6473165e9a7934065d989cd0fe74b621dd7
-size 4824
+oid sha256:a81dbe8352aec2598e0a1326942234dc141237f6dcff2424ef3a511ff823e74d
+size 4837

--- a/Assets/Prefabs/Singletons.prefab
+++ b/Assets/Prefabs/Singletons.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71eb2342ba1e692bfb19adc8c0e157e51f8152c0e9b9a3fc6f24a57366d31d44
-size 3530
+oid sha256:a5e21a955fcef01be8fefddf7f37b6473165e9a7934065d989cd0fe74b621dd7
+size 4824

--- a/Assets/Scenes/Test Room.unity
+++ b/Assets/Scenes/Test Room.unity
@@ -6103,28 +6103,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 721098851681381965, guid: cd550b6cfbc0a584baa3fd3620251073, type: 3}
   m_PrefabInstance: {fileID: 1925965648}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1449021201 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4070147436889792620, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
-  m_PrefabInstance: {fileID: 2142788100}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1449021203
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1449021201}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e1b00732d659dec4ebeddc3aae0adafd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  PlayerCamera: {fileID: 0}
-  Axes:
-    x: 1
-    y: 0
-    z: 0
 --- !u!1 &1450831304
 GameObject:
   m_ObjectHideFlags: 3
@@ -7293,21 +7271,13 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 2835570360041755394, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
-      propertyPath: inventory
+    - target: {fileID: 2142788102, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
+      propertyPath: InventoryGameObject
       value: 
-      objectReference: {fileID: 11400000, guid: b9b4e9a6db9fedc4886de5e00d0f9aa9, type: 2}
-    - target: {fileID: 3087787469182424144, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.77
-      objectReference: {fileID: 0}
-    - target: {fileID: 3087787469182424144, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.76
-      objectReference: {fileID: 0}
-    - target: {fileID: 3087787469182424144, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.534
+      objectReference: {fileID: 1979878985}
+    - target: {fileID: 2835570360041755394, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
+      propertyPath: AudioName
+      value: lete
       objectReference: {fileID: 0}
     - target: {fileID: 4908435617563147631, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
       propertyPath: m_RootOrder
@@ -7359,42 +7329,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
---- !u!1 &2142788101 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4908435617563147633, guid: 604f43983d5510b4b8101958f2ed4ec7, type: 3}
-  m_PrefabInstance: {fileID: 2142788100}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &2142788102
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2142788101}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 216369b8a4f100947afc6a15d4c6ebe2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  InventoryGameObject: {fileID: 1979878985}
-  IsCursorVisibleInInventory: 1
---- !u!114 &2142788108
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2142788101}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e1b00732d659dec4ebeddc3aae0adafd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  PlayerCamera: {fileID: 0}
-  Axes:
-    x: 0
-    y: 1
-    z: 0
 --- !u!1001 &341506470468558456
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Common/Sound.cs
+++ b/Assets/Scripts/Common/Sound.cs
@@ -1,6 +1,5 @@
 using System;
 using UnityEngine;
-using UnityEngine.Audio;
 
 namespace ProjectWendigo
 {
@@ -8,14 +7,17 @@ namespace ProjectWendigo
     public class Sound
     {
         public string Name;
+        public AudioClip Clip;
+
         public bool IsLooping = false;
         [Range(0f, 1f)]
         public float Volume = 1f;
-        [Range(0f, 1f)]
-        public float Pitch = 0f;
+        [Range(.1f, 3f)]
+        public float Pitch = 1f;
 
-        public AudioClip Clip;
-        [HideInInspector]
-        public AudioSource Source;
+        public float FullLength
+        {
+            get => this.Clip.length * 1f / this.Pitch;
+        }
     }
 }

--- a/Assets/Scripts/Common/Sound.cs
+++ b/Assets/Scripts/Common/Sound.cs
@@ -1,0 +1,21 @@
+using System;
+using UnityEngine;
+using UnityEngine.Audio;
+
+namespace ProjectWendigo
+{
+    [Serializable]
+    public class Sound
+    {
+        public string Name;
+        public bool IsLooping = false;
+        [Range(0f, 1f)]
+        public float Volume = 1f;
+        [Range(0f, 1f)]
+        public float Pitch = 0f;
+
+        public AudioClip Clip;
+        [HideInInspector]
+        public AudioSource Source;
+    }
+}

--- a/Assets/Scripts/Common/Sound.cs.meta
+++ b/Assets/Scripts/Common/Sound.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07debdab74666ef4bb14a12faf610431
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Player/PlayerController.cs
+++ b/Assets/Scripts/Gameplay/Player/PlayerController.cs
@@ -4,16 +4,10 @@ namespace ProjectWendigo
 {
     public class PlayerController : MonoBehaviour
     {
-        private Transform _cameraTransform;
         [SerializeField] private CharacterController _characterController;
         private Vector3 _motion = Vector3.zero;
         public InventoryObject inventory;
         //public ItemPickup itemPickup;
-
-        protected void Awake()
-        {
-            this._cameraTransform = Camera.main.transform;
-        }
 
         protected void OnApplicationQuit()
         {

--- a/Assets/Scripts/Singletons/Singletons.cs
+++ b/Assets/Scripts/Singletons/Singletons.cs
@@ -7,6 +7,7 @@ namespace ProjectWendigo
         public static Singletons Main { get; private set; }
 
         public InputManager Input { get; private set; }
+        public SoundManager Sound { get; private set; }
 
         public void Awake()
         {
@@ -17,7 +18,10 @@ namespace ProjectWendigo
             }
             Main = this;
 
+            DontDestroyOnLoad(this.gameObject);
+
             Main.Input = this.GetComponentInChildren<InputManager>();
+            Main.Sound = this.GetComponentInChildren<SoundManager>();
         }
     }
 }

--- a/Assets/Scripts/Singletons/SoundManager.cs
+++ b/Assets/Scripts/Singletons/SoundManager.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using System;
+
+namespace ProjectWendigo
+{
+    public class SoundManager : MonoBehaviour
+    {
+        public Sound[] Sounds;
+
+        protected void Awake()
+        {
+            foreach (Sound sound in this.Sounds)
+            {
+                sound.Source = this.gameObject.GetComponent<AudioSource>();
+                sound.Source.clip = sound.Clip;
+                sound.Source.volume = sound.Volume;
+                sound.Source.pitch = sound.Pitch;
+                sound.Source.loop = sound.IsLooping;
+            }
+        }
+
+        public void Play(string audioName)
+        {
+            Sound sound = Array.Find(this.Sounds, sound => sound.Name == audioName);
+            if (sound == null)
+            {
+                Debug.LogWarning($"Sound {audioName} not found.");
+                return;
+            }
+            sound.Source.Play();
+        }
+    }
+}

--- a/Assets/Scripts/Singletons/SoundManager.cs
+++ b/Assets/Scripts/Singletons/SoundManager.cs
@@ -32,14 +32,15 @@ namespace ProjectWendigo
             Sound sound = this.GetSound(name);
             if (sound == null)
                 return null;
-            var gameObject = new GameObject(name);
-            gameObject.transform.position = position;
-            gameObject.transform.parent = this.transform;
+            var soundHandle = new GameObject(name);
+            soundHandle.transform.position = position;
+            soundHandle.transform.parent = this.transform;
             // Destroying the GameObject after the sound duration assumes
             // the sound will be played directly after this method is called.
             // This impedes some use cases of this method but is generally safer.
-            Destroy(gameObject, sound.FullLength);
-            AudioSource audioSource = this.SpawnAudio(gameObject, sound);
+            if (!sound.IsLooping)
+                Destroy(soundHandle, sound.FullLength);
+            AudioSource audioSource = this.SpawnAudio(soundHandle, sound);
             audioSource.spatialBlend = spatialBlend;
             return audioSource;
         }
@@ -82,7 +83,8 @@ namespace ProjectWendigo
             audioSource.volume = sound.Volume;
             audioSource.pitch = sound.Pitch;
             audioSource.loop = sound.IsLooping;
-            Destroy(audioSource, sound.FullLength);
+            if (!sound.IsLooping)
+                Destroy(audioSource, sound.FullLength);
             return audioSource;
         }
     }

--- a/Assets/Scripts/Singletons/SoundManager.cs
+++ b/Assets/Scripts/Singletons/SoundManager.cs
@@ -1,33 +1,89 @@
-using UnityEngine;
 using System;
+using UnityEngine;
 
 namespace ProjectWendigo
 {
     public class SoundManager : MonoBehaviour
     {
-        public Sound[] Sounds;
+        [SerializeField] private Sound[] Sounds;
 
-        protected void Awake()
+        /// <summary>
+        /// Get an AudioSource for the corresponding sound clip.
+        /// </summary>
+        /// <param name="name">Sound clip name from the SoundManager sounds array</param>
+        /// <returns>New AudioSource with the corresponding sound clip if found</returns>
+        public AudioSource GetAudio(string name)
         {
-            foreach (Sound sound in this.Sounds)
-            {
-                sound.Source = this.gameObject.GetComponent<AudioSource>();
-                sound.Source.clip = sound.Clip;
-                sound.Source.volume = sound.Volume;
-                sound.Source.pitch = sound.Pitch;
-                sound.Source.loop = sound.IsLooping;
-            }
+            Sound sound = this.GetSound(name);
+            if (sound == null)
+                return null;
+            return this.SpawnAudio(this.gameObject, sound);
         }
 
-        public void Play(string audioName)
+        /// <summary>
+        /// Get an AudioSource positioned at a given position in world space.
+        /// </summary>
+        /// <param name="name">Sound clip name from the SoundManager sounds array</param>
+        /// <param name="position">Position in world space where the sound should be emitted from</param>
+        /// <param name="spatialBlend">How much the AudioSource is affected by 3D spatialisation calculations</param>
+        /// <returns>New AudioSource with the corresponding sound clip if found</returns>
+        public AudioSource GetAudioAt(string name, Vector3 position, float spatialBlend = 1f)
         {
-            Sound sound = Array.Find(this.Sounds, sound => sound.Name == audioName);
+            Sound sound = this.GetSound(name);
+            if (sound == null)
+                return null;
+            var gameObject = new GameObject(name);
+            gameObject.transform.position = position;
+            gameObject.transform.parent = this.transform;
+            // Destroying the GameObject after the sound duration assumes
+            // the sound will be played directly after this method is called.
+            // This impedes some use cases of this method but is generally safer.
+            Destroy(gameObject, sound.FullLength);
+            AudioSource audioSource = this.SpawnAudio(gameObject, sound);
+            audioSource.spatialBlend = spatialBlend;
+            return audioSource;
+        }
+
+        /// <summary>
+        /// Play the corresponding sound in 2D.
+        /// </summary>
+        /// <param name="name">Sound clip name from the SoundManager sounds array</param>
+        public void Play(string name)
+        {
+            this.GetAudio(name)?.Play();
+        }
+
+        /// <summary>
+        /// Play the corresponding sound at the given position in world space.
+        /// </summary>
+        /// <param name="name">Sound clip name from the SoundManager sounds array</param>
+        /// <param name="position">Position in world space where the sound should be emitted from</param>
+        /// <param name="spatialBlend">How much the AudioSource is affected by 3D spatialisation calculations</param>
+        public void PlayAt(string name, Vector3 position, float spatialBlend = 1f)
+        {
+            this.GetAudioAt(name, position, spatialBlend)?.Play();
+        }
+
+        private Sound GetSound(string name)
+        {
+            Sound sound = Array.Find(this.Sounds, sound => sound.Name == name);
             if (sound == null)
             {
-                Debug.LogWarning($"Sound {audioName} not found.");
-                return;
+                Debug.LogWarning($"Sound {name} not found.");
+                return null;
             }
-            sound.Source.Play();
+            return sound;
+        }
+
+        private AudioSource SpawnAudio(GameObject gameObject, Sound sound)
+        {
+            var audioSource = gameObject.AddComponent<AudioSource>();
+            audioSource.clip = sound.Clip;
+            audioSource.volume = sound.Volume;
+            audioSource.pitch = sound.Pitch;
+            audioSource.loop = sound.IsLooping;
+            Destroy(audioSource, sound.FullLength);
+            return audioSource;
         }
     }
 }

--- a/Assets/Scripts/Singletons/SoundManager.cs.meta
+++ b/Assets/Scripts/Singletons/SoundManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 768dcdb3eabf38f4d9391fe9f31cfb9e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This adds a sound manager object to the `Singletons` prefab, to which audio clips can be attached and given a default configuration (volume, pitch, and looping so far, other settings can be added).

<div align="center">
    <img src="https://user-images.githubusercontent.com/42178413/163660311-97b1679b-e8c0-4703-88a7-fafb67d1d292.png" alt="SoundManager inspector view"/>
    <p><i>SoundManager inspector view</i></p>
</div>

The SoundManager comes with 4 public methods for playing an audio clip in 2D or 3D directly or for getting its AudioSource to customize how it should be played before playing it.

Example:
```csharp
// Play a sound without spatialization.
Singletons.Main.Sound.Play("whispers1");

// Play a 3D sound 2 meters behind the player (assuming this line is attached to a player script).
Singletons.Main.Sound.PlayAt("whispers1", this.transform.position + this.transform.forward * -2f);
```