### PR TITLE
feat: generic trigger box prefab

### DIFF
--- a/Assets/Prefabs/Triggerbox.prefab
+++ b/Assets/Prefabs/Triggerbox.prefab
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce68795aafe3193c8b7b5f92a071bcf1c60d4311c3306331d96365d5f971e4c0
+size 1886

--- a/Assets/Prefabs/Triggerbox.prefab.meta
+++ b/Assets/Prefabs/Triggerbox.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f1a2e9fe71109f34d99d5fc2a582f8fa
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/TriggerBox.meta
+++ b/Assets/Scripts/Gameplay/TriggerBox.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8fac08e38e12664fbd1d7b849014719
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/TriggerBox/TriggerBox.cs
+++ b/Assets/Scripts/Gameplay/TriggerBox/TriggerBox.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace ProjectWendigo
+{
+    public class TriggerBox : MonoBehaviour
+    {
+        public UnityEvent<Collider> OnTriggerBoxEnter;
+        public UnityEvent<Collider> OnTriggerBoxStay;
+        public UnityEvent<Collider> OnTriggerBoxExit;
+
+        private void OnTriggerEnter(Collider other)
+        {
+            this.OnTriggerBoxEnter?.Invoke(other);
+        }
+
+        private void OnTriggerStay(Collider other)
+        {
+            this.OnTriggerBoxStay?.Invoke(other);
+        }
+
+        private void OnTriggerExit(Collider other)
+        {
+            this.OnTriggerBoxExit?.Invoke(other);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/TriggerBox/TriggerBox.cs.meta
+++ b/Assets/Scripts/Gameplay/TriggerBox/TriggerBox.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01df796c583803142a2310d1195b2340
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Generic trigger box

This adds a generic trigger box prefab that can be reused to trigger actions when the player or any other object enters, stays in on leaves a trigger box.

### Creating a trigger box

To add a trigger box to the scene, just drag and drop the `TriggerBox` prefab onto the scene.

A trigger box can be resized or changed to match the desired shape in the inspector, by changing the box collider to another type of collider desired, or by changing its size:

<div align="center">
    <img src="https://user-images.githubusercontent.com/42178413/163687590-34d5e135-fbd4-4df7-81bb-185c61b75522.png" alt="Trigger box collider in inspector"/>
    <p><i>Trigger box collider in inspector</i></p>
</div>

<div align="center">
    <img src="https://user-images.githubusercontent.com/42178413/163687600-f81971e0-083f-45cb-857d-8788ae40cde9.png" alt="Trigger box collider  in the scene"/>
    <p><i>Trigger box collider in the scene</i></p>
</div>

### Binding event handlers to the different trigger box events

Then, event handlers can be bound to the trigger box's different events in the inspector:

<div align="center">
    <img src="https://user-images.githubusercontent.com/42178413/163687499-e5f7e315-0d31-4022-a2c6-90c21655af12.png" alt="Trigger box bindings in inspector"/>
    <p><i>Trigger box bindings in inspector</i></p>
</div>

The trigger box has 3 events:

- `On Trigger Box Enter`: triggers once when an object enters the trigger box.
- `On Trigger Box Stay`: triggers every frame while an object is staying inside the trigger box.
- `On Trigger Box Leave`: triggers once when an object leaves the trigger box.

> **Note**: the collider object is not necessarily the player, so you might want to check this in your handler function. Your handler can take a parameter of type `Collider` to get the object that collided with the trigger box.

An event handler for a trigger box event is simply a method that can have any parameters. If it takes a `Collider` as its only parameter, it will be the object that collided with the trigger box to trigger the event. Otherwise, you can customize the parameter values in the inspector.
An example for a trigger event handler would be:

```csharp
public void EnteredTriggerBox(Collider collider)
{
    Debug.Log("Entered");
    Debug.Log(collider);
}
```

or

```csharp
public void EnteredTriggerBox()
{
    Debug.Log("Entered trigger box");
}
```