### PR TITLE
feat: church event

### DIFF
--- a/Assets/Prefabs/Singletons.prefab
+++ b/Assets/Prefabs/Singletons.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61edaf1a75e9da1223b23306cf44229880e809bc665c7e7bc8ba46eaafca00f7
-size 26480
+oid sha256:47e20a59fa22334bf9839bd61f39ff839ba75e01af065c43a49234f6ac4cfaa3
+size 27914

--- a/Assets/Scripts/Gameplay/Level1/ChurchEvent.cs
+++ b/Assets/Scripts/Gameplay/Level1/ChurchEvent.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using Cinemachine;
+
+namespace ProjectWendigo
+{
+    public class ChurchEvent : MonoBehaviour
+    {
+        private void Awake()
+        {
+            Singletons.Main.Event.On("ChurchEvent", this.EnterEvent);
+        }
+
+        public void EnterEvent()
+        {
+            this.ChangeSensitivity();
+        }
+
+        public void ChangeSensitivity(float sensitivity = 0.005f)
+        { // make issue to remind self about better implementation in optionsmanager
+            // Call OptionsManager Sensitivity function once for each axis.
+
+            // Optionsmanager Sensitivity functions will look like the below...
+
+            // this.gameObject.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_VerticalAxis.m_MaxSpeed = sensitivity;
+            // this.gameObject.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_HorizontalAxis.m_MaxSpeed = sensitivity;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Level1/ChurchEvent.cs.meta
+++ b/Assets/Scripts/Gameplay/Level1/ChurchEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22015e5e4dfb968478439360a8ead6f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Singletons/EventManager.cs
+++ b/Assets/Scripts/Singletons/EventManager.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace ProjectWendigo
+{
+    public class EventManager : MonoBehaviour
+    {
+        [SerializeField] private Dictionary<string, UnityEventBase> _events = new Dictionary<string, UnityEventBase>();
+
+        public EventType GetEvent<EventType>(string eventName)
+             where EventType : class, new()
+        {
+            if (!this._events.ContainsKey(eventName))
+                this._events.Add(eventName, new EventType() as UnityEventBase);
+            EventType evt = this._events[eventName] as EventType;
+            if (evt == null)
+                Debug.LogWarning($"Incompatible event type {this._events[eventName].GetType()} with {typeof(EventType)}");
+            return evt;
+        }
+
+        public void On(string eventName, UnityAction listener)
+        {
+            this.GetEvent<UnityEvent>(eventName)?.AddListener(listener);
+        }
+
+        public void On<T0>(string eventName, UnityAction<T0> listener)
+        {
+            this.GetEvent<UnityEvent<T0>>(eventName)?.AddListener(listener);
+        }
+
+        public void On<T0, T1>(string eventName, UnityAction<T0, T1> listener)
+        {
+            this.GetEvent<UnityEvent<T0, T1>>(eventName)?.AddListener(listener);
+        }
+
+        public void On<T0, T1, T2>(string eventName, UnityAction<T0, T1, T2> listener)
+        {
+            this.GetEvent<UnityEvent<T0, T1, T2>>(eventName)?.AddListener(listener);
+        }
+
+        public void On<T0, T1, T2, T3>(string eventName, UnityAction<T0, T1, T2, T3> listener)
+        {
+            this.GetEvent<UnityEvent<T0, T1, T2, T3>>(eventName)?.AddListener(listener);
+        }
+
+        public void Trigger(string eventName)
+        {
+            this.GetEvent<UnityEvent>(eventName)?.Invoke();
+        }
+
+        public void Trigger<T0>(string eventName, T0 arg0)
+        {
+            this.GetEvent<UnityEvent<T0>>(eventName)?.Invoke(arg0);
+        }
+
+        public void Trigger<T0, T1>(string eventName, T0 arg0, T1 arg1)
+        {
+            this.GetEvent<UnityEvent<T0, T1>>(eventName)?.Invoke(arg0, arg1);
+        }
+
+        public void Trigger<T0, T1, T2>(string eventName, T0 arg0, T1 arg1, T2 arg2)
+        {
+            this.GetEvent<UnityEvent<T0, T1, T2>>(eventName)?.Invoke(arg0, arg1, arg2);
+        }
+
+        public void Trigger<T0, T1, T2, T3>(string eventName, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+        {
+            this.GetEvent<UnityEvent<T0, T1, T2, T3>>(eventName)?.Invoke(arg0, arg1, arg2, arg3);
+        }
+    }
+}

--- a/Assets/Scripts/Singletons/EventManager.cs.meta
+++ b/Assets/Scripts/Singletons/EventManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04c9c6c334e18a24491410e3f7868389
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Singletons/Singletons.cs
+++ b/Assets/Scripts/Singletons/Singletons.cs
@@ -17,6 +17,7 @@ namespace ProjectWendigo
         public SceneSwitcher Scene { get; private set; }
         public InterfaceManager Interface { get; private set; }
         public QuestManager Quest { get; private set; }
+        public EventManager Event { get; private set; }
 
         public void Awake()
         {
@@ -38,6 +39,7 @@ namespace ProjectWendigo
             Main.Scene = this.GetComponentInChildren<SceneSwitcher>();
             Main.Interface = this.GetComponentInChildren<InterfaceManager>();
             Main.Quest = this.GetComponentInChildren<QuestManager>();
+            Main.Event = this.GetComponentInChildren<EventManager>();
         }
     }
 }


### PR DESCRIPTION
Feature
---

**Related problem to feature request**

Missing church event for level 1.

**Solution or enhancement to problem**

This branch adds an `EventManager` singleton, which triggers the `ChurchEvent` class.

**Dependencies to the feature request**

This solution does not include the complete functionality of the church event. To complete the church event, the `ChurchEvent` class must be able to communicate to the `OptionsManager` singleton, which does not exist in the current context. This will be resolved in a future branch.

**Additional context**

``` c#
public class EventManager : MonoBehaviour
    {
        public UnityEvent EarthquakeEvent;
        public UnityEvent ChurchEvent;

        public void Earthquake()
        {
            this.EarthquakeEvent?.Invoke();
        }

        public void Church()
        {
            this.ChurchEvent?.Invoke();
        }
    }
```

``` c#
public class ChurchEvent : MonoBehaviour
    {
        public void EnterEvent()
        {
            this.ChangeSensitivity();
        }

        public void ChangeSensitivity(float sensitivity = 0.005f) { // make issue to remind self about better implementation in optionsmanager
            // this.gameObject.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_VerticalAxis.m_MaxSpeed = sensitivity;
            // this.gameObject.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_HorizontalAxis.m_MaxSpeed = sensitivity;
        }
    }
```