### PR TITLE
hotfix: fix player gravity bug

### DIFF
--- a/Assets/Scripts/Gameplay/Player/PlayerMovementStateContext.cs
+++ b/Assets/Scripts/Gameplay/Player/PlayerMovementStateContext.cs
@@ -32,6 +32,14 @@ namespace ProjectWendigo
             this.SmoothSpeedMultiplier = Mathf.Lerp(this.SmoothSpeedMultiplier, this.SpeedMultiplier, 4f * Time.deltaTime);
             base.Update();
             this.Move();
+
+            Vector3 moveVector = Vector3.zero;
+
+            if (this.IsGrounded == false) {
+                moveVector += Physics.gravity;
+            }
+
+            _characterController.Move(moveVector * Time.deltaTime);
         }
 
         /// <summary>


### PR DESCRIPTION
### Player gravity bug fixed

In the past when hugging the wall when you walk up some stones, the character won't go back down again. Gravity is now handled in the player movement script as shown in the picture below. This solution closes #45.

![afbeelding](https://user-images.githubusercontent.com/47192822/174452765-7990b0d9-57ff-475c-9cc7-0c8dd89bdd15.png)
