### PR TITLE
feat: quest manager and intro level quest

### DIFF
--- a/Assets/Prefabs/Singletons.prefab
+++ b/Assets/Prefabs/Singletons.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd3cb1de6d88a786723a1a0deb8e3bbeb48ddbd87f4946db3bf51d0baeb9931d
-size 24738
+oid sha256:61edaf1a75e9da1223b23306cf44229880e809bc665c7e7bc8ba46eaafca00f7
+size 26480

--- a/Assets/Scenes/IntroLevel.unity
+++ b/Assets/Scenes/IntroLevel.unity
@@ -201,7 +201,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7203195339672445014, guid: d1dff9c2d6c95e94fa82cd4465b20f10, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 7203195339672445014, guid: d1dff9c2d6c95e94fa82cd4465b20f10, type: 3}
       propertyPath: m_LocalScale.x
@@ -285,6 +285,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d1dff9c2d6c95e94fa82cd4465b20f10, type: 3}
+--- !u!1 &22887830 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4045383631357877282, guid: 5d7dff6f818914b4397692416a57738c, type: 3}
+  m_PrefabInstance: {fileID: 453689929}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &33774744 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 471303674924826749, guid: f2cd5f225ae55114a983744990559fb3, type: 3}
@@ -308,6 +313,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ArchiveEntryTitle: An old doll
+  RelatedQuestName: Intro_CollectLoreItems
 --- !u!4 &156916228 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1564658314008724390, guid: fac30e8159a9e2543817818bf6d8bb17, type: 3}
@@ -320,6 +326,82 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[0].Name
+      value: Intro_CollectLoreItems
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[1].Name
+      value: Intro_CollectGear
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[0].Total
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[1].Total
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[0].OnComplete.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[1].OnComplete.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[0].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[1].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[0].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1617535184}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[1].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1617535184}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[0].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[1].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[0].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnAllLoreItemsCollected
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[1].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnAllGearCollected
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[0].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ProjectWendigo.DepartureEvent, Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[1].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: ProjectWendigo.DepartureEvent, Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[0].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 267003903581154859, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _quests.Array.data[1].OnComplete.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 674071865414420883, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -10288.232
@@ -532,62 +614,6 @@ PrefabInstance:
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.size
-      value: 51
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[48].Clip
-      value: 
-      objectReference: {fileID: 8300000, guid: d6e2bff9800a178488b1bddfc365a287, type: 3}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[48].Name
-      value: cabin_phone_voice
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[49].Clip
-      value: 
-      objectReference: {fileID: 8300000, guid: 9c5a3d1b2f016f040a5189954b335b6c, type: 3}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[49].Name
-      value: pickup_gear
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[50].Clip
-      value: 
-      objectReference: {fileID: 8300000, guid: 14d3bd68f151f3548980b1e8d29f3948, type: 3}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[50].Name
-      value: pickup_gun
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[48].Pitch
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[49].Pitch
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[50].Pitch
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[45].Volume
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[48].Volume
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[49].Volume
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8996772556658380983, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
-      propertyPath: Sounds.Array.data[50].Volume
-      value: 0.03
-      objectReference: {fileID: 0}
     - target: {fileID: 9058821936876570431, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -667,35 +693,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.6608
+      value: 2.839
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.682426
+      value: -0.433
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.28075933
+      value: -4.893
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -703,7 +729,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3971029729222616045, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -731,7 +757,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7790998383309081236, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
       propertyPath: m_Layer
-      value: 8
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
@@ -745,7 +771,7 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 715459251039819549, guid: 8ae6c01e5dd08f24983aa9e6fea4d0a6, type: 3}
   m_PrefabInstance: {fileID: 311512755}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &311512758
+--- !u!114 &311512759
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -754,18 +780,19 @@ MonoBehaviour:
   m_GameObject: {fileID: 311512756}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e930cf89b02737547960c9d3eac84609, type: 3}
+  m_Script: {fileID: 11500000, guid: 716f7142632a61d46ad104c43949e082, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _inWorldItem: {fileID: 311512757}
   _inHandItem: {fileID: 0}
   _onPickUpSoundName: pickup_gun
+  RelatedQuestName: Intro_CollectGear
 --- !u!1 &370327869 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2941313240270121520, guid: 67c4d68b20a99204aac1ed89f460d1ab, type: 3}
   m_PrefabInstance: {fileID: 1644682872}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &370327870
+--- !u!114 &370327871
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -774,12 +801,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 370327869}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e930cf89b02737547960c9d3eac84609, type: 3}
+  m_Script: {fileID: 11500000, guid: 716f7142632a61d46ad104c43949e082, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _inWorldItem: {fileID: 1716399136}
+  _inWorldItem: {fileID: 370327869}
   _inHandItem: {fileID: 0}
   _onPickUpSoundName: pickup_gear
+  RelatedQuestName: Intro_CollectGear
 --- !u!4 &388553353 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8506012369544167204, guid: 7a90cd0e33ee855438c28abe070d73a2, type: 3}
@@ -852,7 +880,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1716399137}
+    m_TransformParent: {fileID: 1337826826}
     m_Modifications:
     - target: {fileID: 3706399091789678232, guid: 5d7dff6f818914b4397692416a57738c, type: 3}
       propertyPath: m_RootOrder
@@ -860,15 +888,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3706399091789678232, guid: 5d7dff6f818914b4397692416a57738c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.2548
+      value: -2.196
       objectReference: {fileID: 0}
     - target: {fileID: 3706399091789678232, guid: 5d7dff6f818914b4397692416a57738c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.707426
+      value: -1.497
       objectReference: {fileID: 0}
     - target: {fileID: 3706399091789678232, guid: 5d7dff6f818914b4397692416a57738c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.60275936
+      value: -1.892
       objectReference: {fileID: 0}
     - target: {fileID: 3706399091789678232, guid: 5d7dff6f818914b4397692416a57738c, type: 3}
       propertyPath: m_LocalRotation.w
@@ -904,7 +932,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4388476003200201844, guid: 5d7dff6f818914b4397692416a57738c, type: 3}
       propertyPath: m_Layer
-      value: 8
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5d7dff6f818914b4397692416a57738c, type: 3}
@@ -918,6 +946,23 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 9029836985463642941, guid: 1241f58223e92d04caf98d0dbf2189e5, type: 3}
   m_PrefabInstance: {fileID: 6948499}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &565864188 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8744749171976155091, guid: fe6c649adb395af429fe1d174560e8a0, type: 3}
+  m_PrefabInstance: {fileID: 2130060497}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &565864189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 565864188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f3942af6f7abb434a9f9c2905b6ed14c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &568457791 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3689755322571063947, guid: 99f689c1c6a793c498fd4b14ec427c22, type: 3}
@@ -5777,7 +5822,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 809438726334435077, guid: 96bc6502a42677b4f826794a7f3543d1, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 809438726334435077, guid: 96bc6502a42677b4f826794a7f3543d1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6231,7 +6276,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1716399137}
+  - {fileID: 453689930}
+  - {fileID: 1644682873}
   - {fileID: 2130060498}
   - {fileID: 1915695104}
   - {fileID: 1369186056}
@@ -6379,7 +6425,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3689755322571063947, guid: 99f689c1c6a793c498fd4b14ec427c22, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 3689755322571063947, guid: 99f689c1c6a793c498fd4b14ec427c22, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6465,6 +6511,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1617535183}
+  - component: {fileID: 1617535184}
   m_Layer: 0
   m_Name: Level
   m_TagString: Untagged
@@ -6503,12 +6550,32 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1617535184
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617535182}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c833fb0c2fd45904f8722f9611cbfd7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PhoneCallTriggerDelay: 15
+  PhoneInteractableCollider: {fileID: 1662190982}
+  PhoneStateContext: {fileID: 1972079157}
+  CarKeyInteractableCollider: {fileID: 565864188}
+  InteractableItems:
+  - {fileID: 370327869}
+  - {fileID: 1655138249}
+  - {fileID: 311512756}
 --- !u!1001 &1644682872
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1716399137}
+    m_TransformParent: {fileID: 1337826826}
     m_Modifications:
     - target: {fileID: 2565490903905235082, guid: 67c4d68b20a99204aac1ed89f460d1ab, type: 3}
       propertyPath: m_RootOrder
@@ -6524,7 +6591,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2565490903905235082, guid: 67c4d68b20a99204aac1ed89f460d1ab, type: 3}
       propertyPath: m_LocalScale.z
-      value: 3.1152515
+      value: 3.1152518
       objectReference: {fileID: 0}
     - target: {fileID: 2565490903905235082, guid: 67c4d68b20a99204aac1ed89f460d1ab, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6572,7 +6639,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2941313240270121520, guid: 67c4d68b20a99204aac1ed89f460d1ab, type: 3}
       propertyPath: m_Layer
-      value: 8
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4019557841505830020, guid: 67c4d68b20a99204aac1ed89f460d1ab, type: 3}
       propertyPath: m_Convex
@@ -6607,12 +6674,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ArchiveEntryTitle: Trophy
+  RelatedQuestName: Intro_CollectLoreItems
 --- !u!1 &1655138249 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4388476003200201844, guid: 5d7dff6f818914b4397692416a57738c, type: 3}
   m_PrefabInstance: {fileID: 453689929}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1655138252
+--- !u!114 &1655138250
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6621,12 +6689,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1655138249}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e930cf89b02737547960c9d3eac84609, type: 3}
+  m_Script: {fileID: 11500000, guid: 716f7142632a61d46ad104c43949e082, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _inWorldItem: {fileID: 1716399136}
+  _inWorldItem: {fileID: 22887830}
   _inHandItem: {fileID: 0}
   _onPickUpSoundName: pickup_gear
+  RelatedQuestName: Intro_CollectGear
 --- !u!1 &1662190982 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2108900648524252654, guid: 96bc6502a42677b4f826794a7f3543d1, type: 3}
@@ -6759,38 +6828,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c099200af26b8e24c937b678eec2a037, type: 3}
---- !u!1 &1716399136
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1716399137}
-  m_Layer: 0
-  m_Name: Gear
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1716399137
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1716399136}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 453689930}
-  - {fileID: 1644682873}
-  m_Father: {fileID: 1337826826}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!850595691 &1722405040
 LightingSettings:
   m_ObjectHideFlags: 0
@@ -7009,7 +7046,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4440625504372979601, guid: 22279f008707902479dfadc8e8f0290d, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4440625504372979601, guid: 22279f008707902479dfadc8e8f0290d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7222,7 +7259,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de3b0258ab09f0644aab5f4700f6ee40, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  RingDelay: 20
+  OnChangeState:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &1979431209 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4164005856954696725, guid: 99f689c1c6a793c498fd4b14ec427c22, type: 3}
@@ -7241,6 +7280,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ArchiveEntryTitle: Framed Picture
+  RelatedQuestName: Intro_CollectLoreItems
 --- !u!1 &2040008918
 GameObject:
   m_ObjectHideFlags: 0
@@ -7299,7 +7339,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5469044003388815629, guid: fe6c649adb395af429fe1d174560e8a0, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5469044003388815629, guid: fe6c649adb395af429fe1d174560e8a0, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/Common/AStateContext.cs
+++ b/Assets/Scripts/Common/AStateContext.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Events;
 
 /// <summary>
 /// State context abstract base class. A state context is responsible for
@@ -9,6 +10,8 @@ using UnityEngine;
 /// </summary>
 public abstract class AStateContext : MonoBehaviour
 {
+    public UnityEvent<AStateContext, IState> OnChangeState;
+
     private IState _state;
 
     public IState State
@@ -35,6 +38,7 @@ public abstract class AStateContext : MonoBehaviour
         this._state = value;
         value.SetContext(this);
         this._state.Enter();
+        this.OnChangeState?.Invoke(this, this._state);
     }
 
     protected virtual void FixedUpdate()

--- a/Assets/Scripts/Extensions/SetObjectInteractable.cs
+++ b/Assets/Scripts/Extensions/SetObjectInteractable.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+namespace ProjectWendigo
+{
+    public static class SetObjectInteractable
+    {
+        public static void SetInteractable(this GameObject target)
+        {
+            target.layer = LayerMask.NameToLayer("Interactable");
+        }
+
+        public static void SetInteractable(this GameObject target, out int previousLayer)
+        {
+            previousLayer = target.layer;
+            target.layer = LayerMask.NameToLayer("Interactable");
+        }
+    }
+}

--- a/Assets/Scripts/Extensions/SetObjectInteractable.cs.meta
+++ b/Assets/Scripts/Extensions/SetObjectInteractable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88bb70ce2a27b9b4bb4b832e42954406
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/InteractableLoreItem.cs
+++ b/Assets/Scripts/Gameplay/InteractableLoreItem.cs
@@ -5,6 +5,7 @@ namespace ProjectWendigo
     public class InteractableLoreItem : AInteractable
     {
         public string ArchiveEntryTitle;
+        public string RelatedQuestName;
 
         public override void OnLookAt(GameObject target)
         {
@@ -26,6 +27,8 @@ namespace ProjectWendigo
         {
             if (!Singletons.Main.Notebook.ArchiveHasEntry(this.ArchiveEntryTitle))
             {
+                if (this.RelatedQuestName != "")
+                    Singletons.Main.Quest.TryUpdateQuestProgress(this.RelatedQuestName, 1);
                 Singletons.Main.Notebook.AddArchiveEntryByTitle(this.ArchiveEntryTitle);
                 Singletons.Main.Interface.CloseMessagePanel();
                 Singletons.Main.Save.Save();

--- a/Assets/Scripts/Gameplay/Level0/CarKey.meta
+++ b/Assets/Scripts/Gameplay/Level0/CarKey.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f47d0a8cde603842b865ab57c92efc8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Level0/CarKey/CarKeyInteraction.cs
+++ b/Assets/Scripts/Gameplay/Level0/CarKey/CarKeyInteraction.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace ProjectWendigo
+{
+    public class CarKeyInteraction : AInteractable
+    {
+        public override void OnLookAt(GameObject target)
+        {
+            Singletons.Main.Interface.OpenMessagePanel("- Press F to leave -");
+        }
+
+        public override void OnInteract(GameObject target)
+        {
+            Debug.Log("Leave");
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Level0/CarKey/CarKeyInteraction.cs.meta
+++ b/Assets/Scripts/Gameplay/Level0/CarKey/CarKeyInteraction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3942af6f7abb434a9f9c2905b6ed14c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Level0/Events.meta
+++ b/Assets/Scripts/Gameplay/Level0/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a938a139f67c5ad4680601ea9a6ae891
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Level0/Events/DepartureEvent.cs
+++ b/Assets/Scripts/Gameplay/Level0/Events/DepartureEvent.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using UnityEngine;
+
+namespace ProjectWendigo
+{
+    public class DepartureEvent : MonoBehaviour
+    {
+        public float PhoneCallTriggerDelay = 5f;
+        public GameObject PhoneInteractableCollider;
+        public PhoneStateContext PhoneStateContext;
+        public GameObject CarKeyInteractableCollider;
+        public GameObject[] InteractableItems = new GameObject[0];
+
+        private void Awake()
+        {
+            Singletons.Main.Quest.TryStartQuest("Intro_CollectLoreItems");
+        }
+
+        private IEnumerator TriggerPhoneRingAfterDelay()
+        {
+            yield return new WaitForSeconds(this.PhoneCallTriggerDelay);
+            this.PhoneStateContext.GoToRing();
+            this.PhoneInteractableCollider.SetInteractable();
+            this.PhoneStateContext.OnChangeState.AddListener((ctx, _) =>
+            {
+                if (ctx.IsInState<PhoneStates.Calling>())
+                    this.OnCallAnswered();
+            });
+        }
+
+        public void OnAllLoreItemsCollected()
+        {
+            StartCoroutine(this.TriggerPhoneRingAfterDelay());
+        }
+
+        public void OnCallAnswered()
+        {
+            Singletons.Main.Quest.TryStartQuest("Intro_CollectGear");
+            foreach (GameObject item in this.InteractableItems)
+                item.SetInteractable();
+        }
+
+        public void OnAllGearCollected()
+        {
+            this.CarKeyInteractableCollider.SetInteractable();
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Level0/Events/DepartureEvent.cs.meta
+++ b/Assets/Scripts/Gameplay/Level0/Events/DepartureEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c833fb0c2fd45904f8722f9611cbfd7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Level0/Gear.meta
+++ b/Assets/Scripts/Gameplay/Level0/Gear.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a228d1ba7de59b4484748a3a47082ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Level0/Gear/PickableGear.cs
+++ b/Assets/Scripts/Gameplay/Level0/Gear/PickableGear.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+namespace ProjectWendigo
+{
+    public class PickableGear : Pickable
+    {
+        public string RelatedQuestName;
+
+        private bool _wasPickedUp = false;
+
+        public override void OnInteract(GameObject target)
+        {
+            base.OnInteract(target);
+            if (!this._wasPickedUp)
+            {
+                Singletons.Main.Quest.TryUpdateQuestProgress(this.RelatedQuestName, 1);
+                Singletons.Main.Interface.CloseMessagePanel();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Level0/Gear/PickableGear.cs.meta
+++ b/Assets/Scripts/Gameplay/Level0/Gear/PickableGear.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 716f7142632a61d46ad104c43949e082
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Level0/Phone/PhoneStateContext.cs
+++ b/Assets/Scripts/Gameplay/Level0/Phone/PhoneStateContext.cs
@@ -2,8 +2,6 @@ namespace ProjectWendigo
 {
     public class PhoneStateContext : AStateContext
     {
-        public float RingDelay = 45f;
-
         private void Start()
         {
             this.SetState(new PhoneStates.Idle());

--- a/Assets/Scripts/Gameplay/Level0/Phone/PhoneStates/Calling.cs
+++ b/Assets/Scripts/Gameplay/Level0/Phone/PhoneStates/Calling.cs
@@ -4,11 +4,13 @@ namespace ProjectWendigo.PhoneStates
 {
     public class Calling : AState<PhoneStateContext>
     {
-        [SerializeField] private string _callSoundName = "cabin_phone_static";
+        [SerializeField] private string _callStaticSoundName = "cabin_phone_static";
+        [SerializeField] private string _callVoiceSoundName = "cabin_phone_voice";
 
         override public void Enter()
         {
-            Singletons.Main.Sound.PlayAt(this._callSoundName, this.context.transform.position);
+            Singletons.Main.Sound.PlayAt(this._callStaticSoundName, this.context.transform.position);
+            Singletons.Main.Sound.PlayAt(this._callVoiceSoundName, this.context.transform.position);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/Level0/Phone/PhoneStates/Idle.cs
+++ b/Assets/Scripts/Gameplay/Level0/Phone/PhoneStates/Idle.cs
@@ -1,19 +1,6 @@
-using UnityEngine;
-using System.Collections.Generic;
-
 namespace ProjectWendigo.PhoneStates
 {
     public class Idle : AState<PhoneStateContext>
     {
-        private static bool _hasRang = false;
-
-        override public void Update()
-        {
-            if (!_hasRang)
-            {
-                this.context.Invoke("GoToRing", this.context.RingDelay);
-                Idle._hasRang = true;
-            }
-        }
     }
 }

--- a/Assets/Scripts/Singletons/QuestManager.cs
+++ b/Assets/Scripts/Singletons/QuestManager.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+using UnityEngine.Events;
+using System.Linq;
+
+namespace ProjectWendigo
+{
+    public class QuestManager : MonoBehaviour
+    {
+        [System.Serializable]
+        public class Quest
+        {
+            public string Name;
+            public int Progress { get; private set; }
+            public int Total;
+            [SerializeField, ReadOnly] private bool _isStarted = false;
+
+            public UnityEvent<Quest> OnStart;
+            public UnityEvent<Quest> OnProgress;
+            public UnityEvent<Quest> OnComplete;
+
+            public void Start()
+            {
+                if (this._isStarted)
+                {
+                    Debug.LogWarning($"Quest {this.Name} already started");
+                    return;
+                }
+                this._isStarted = true;
+                this.Progress = 0;
+                this.OnStart?.Invoke(this);
+            }
+
+            public void UpdateProgress(int increment)
+            {
+                if (!this._isStarted)
+                {
+                    Debug.LogWarning($"Quest {this.Name} not started yet");
+                    return;
+                }
+                this.Progress = Mathf.Min(this.Progress + increment, this.Total);
+                this.OnProgress?.Invoke(this);
+                if (this.Progress == this.Total)
+                    this.OnComplete?.Invoke(this);
+            }
+        }
+
+        [SerializeField] private Quest[] _quests;
+
+        public Quest GetQuest(string name)
+        {
+            Quest quest = this._quests.First(quest => quest.Name == name);
+            if (quest == null)
+                Debug.LogWarning($"Quest `{name}` does not exist");
+            return quest;
+        }
+
+        public bool TryStartQuest(string name)
+        {
+            Quest quest = this.GetQuest(name);
+            if (quest == null)
+                return false;
+            quest.Start();
+            return true;
+        }
+
+        public bool TryUpdateQuestProgress(string name, int increment)
+        {
+            Quest quest = this.GetQuest(name);
+            if (quest == null)
+                return false;
+            quest.UpdateProgress(increment);
+            return true;
+        }
+
+        public bool TryGetQuestProgress(string name, out int progress)
+        {
+            progress = 0;
+            Quest quest = this.GetQuest(name);
+            if (quest == null)
+                return false;
+            progress = quest.Progress;
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Singletons/QuestManager.cs.meta
+++ b/Assets/Scripts/Singletons/QuestManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d43695b29cdec9146abb98f7868438dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Singletons/Singletons.cs
+++ b/Assets/Scripts/Singletons/Singletons.cs
@@ -15,7 +15,8 @@ namespace ProjectWendigo
         public CameraManager Camera { get; private set; }
         public OptionsManager Option { get; private set; }
         public SceneSwitcher Scene { get; private set; }
-        public InterfaceManager Interface { get; private set;}
+        public InterfaceManager Interface { get; private set; }
+        public QuestManager Quest { get; private set; }
 
         public void Awake()
         {
@@ -36,6 +37,7 @@ namespace ProjectWendigo
             Main.Option = this.GetComponentInChildren<OptionsManager>();
             Main.Scene = this.GetComponentInChildren<SceneSwitcher>();
             Main.Interface = this.GetComponentInChildren<InterfaceManager>();
+            Main.Quest = this.GetComponentInChildren<QuestManager>();
         }
     }
 }


### PR DESCRIPTION
# Feature

This adds a `QuestManager` singleton that holds quests. Quests can be started, progressed, and once their progress has reached the total expected progress, they're marked as complete. On each step, an event is triggered, that can be listened to by other scripts.

This PR also implements the intro level quest (collecting lore items before the phone rings, and collecting the gear before collecting the car key to leave the intro level).

## Additional context

### Quest interface

```csharp
public class Quest
{
   public string Name;
   public int Progress { get; private set; }
   public int Total;
   [SerializeField, ReadOnly] private bool _isStarted = false;

   public UnityEvent<Quest> OnStart;
   public UnityEvent<Quest> OnProgress;
   public UnityEvent<Quest> OnComplete;

   public void Start();
   public void UpdateProgress(int increment);
}
```

### QuestManager API

```csharp
Quest GetQuest(string name);
bool TryStartQuest(string name);
bool TryUpdateQuestProgress(string name, int increment);
bool TryGetQuestProgress(string name, out int progress);
```

### QuestManager view in Inspector

![image](https://user-images.githubusercontent.com/42178413/174493753-ded73b81-18bc-4b1a-b3c6-de40be31be28.png)

## Related tasks

Fixes [AB#414](https://dev.azure.com/Dark-Ocean-Interactive/efeb1545-e1ba-48b4-a22c-021546c992fd/_workitems/edit/414)