### PR TITLE
feat: add ChangeSensitivity singleton method

### DIFF
--- a/Assets/Scenes/IntroLevel.unity
+++ b/Assets/Scenes/IntroLevel.unity
@@ -466,6 +466,10 @@ PrefabInstance:
       propertyPath: _volume
       value: 
       objectReference: {fileID: 1812873530}
+    - target: {fileID: 1825139813449878400, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+      propertyPath: _cinemachineVirtualCamera
+      value: 
+      objectReference: {fileID: 276917888}
     - target: {fileID: 3040920608181718938, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -704,6 +708,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+--- !u!1 &276917888 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2359642140095831289, guid: 721d8fe802e3a7b419f90abf4e3323c9, type: 3}
+  m_PrefabInstance: {fileID: 276917887}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &311512755
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Test Room.unity
+++ b/Assets/Scenes/Test Room.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657624, g: 0.49641395, b: 0.5748183, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657588, g: 0.4964133, b: 0.5748171, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scripts/Gameplay/Level1/ChurchEvent.cs
+++ b/Assets/Scripts/Gameplay/Level1/ChurchEvent.cs
@@ -5,24 +5,29 @@ namespace ProjectWendigo
 {
     public class ChurchEvent : MonoBehaviour
     {
+        [SerializeField] public float Duration = 3f;
+
         private void Awake()
         {
             Singletons.Main.Event.On("ChurchEvent", this.EnterEvent);
         }
 
+        void Start()
+        {
+            Singletons.Main.Event.Trigger("ChurchEvent");
+        }
+
         public void EnterEvent()
         {
+            var _initialSensitivity = Singletons.Main.Camera.PlayerCamera.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_VerticalAxis.m_MaxSpeed;
             this.ChangeSensitivity();
+            this.GetComponent<NearingBreathing>().Trigger(this.Duration);
+            this.Invoke(nameof(this.ChangeSensitivity), this.Duration, _initialSensitivity);
         }
 
         public void ChangeSensitivity(float sensitivity = 0.005f)
-        { // make issue to remind self about better implementation in optionsmanager
-            // Call OptionsManager Sensitivity function once for each axis.
-
-            // Optionsmanager Sensitivity functions will look like the below...
-
-            // this.gameObject.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_VerticalAxis.m_MaxSpeed = sensitivity;
-            // this.gameObject.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_HorizontalAxis.m_MaxSpeed = sensitivity;
+        {
+            Singletons.Main.Option.ChangeSensitivity(sensitivity, sensitivity);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/Level1/ChurchEvent/NearingBreathing.cs
+++ b/Assets/Scripts/Gameplay/Level1/ChurchEvent/NearingBreathing.cs
@@ -21,8 +21,9 @@ namespace ProjectWendigo
             this._spline.DrawGizmos(this.transform.position + Vector3.up - Vector3.right * 0.5f);
         }
 
-        public void Trigger()
+        public void Trigger(float time = 3f)
         {
+            this._time = time;
             Vector3 cameraDirection = Camera.main.transform.forward;
             this._startPosition = Singletons.Main.Player.PlayerBody.transform.position - cameraDirection * this._spawnDistance;
             this._startTime = Time.time;

--- a/Assets/Scripts/Singletons/OptionsManager.cs
+++ b/Assets/Scripts/Singletons/OptionsManager.cs
@@ -17,6 +17,8 @@ namespace ProjectWendigo
         [SerializeField] private HeadbobbingSettingViewModel _headbobbingSettingViewModel;
         [SerializeField] private InvertYSettingViewModel _invertYSettingViewModel;
 
+        [SerializeField] private GameObject _cinemachineVirtualCamera;
+
         public float Volume
         {
             get => this._soundSettingViewModel.VolumeSetting;
@@ -59,6 +61,12 @@ namespace ProjectWendigo
         public void EnablePauseMenu(bool enabled = true)
         {
             this.GetComponent<PauseMenu>().enabled = enabled;
+        }
+
+        public void ChangeSensitivity(float VerticalAxis, float HorizontalAxis)
+        {
+            Singletons.Main.Camera.PlayerCamera.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_VerticalAxis.m_MaxSpeed = VerticalAxis;
+            Singletons.Main.Camera.PlayerCamera.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_HorizontalAxis.m_MaxSpeed = HorizontalAxis;
         }
     }
 }


### PR DESCRIPTION
Feature
---

**Related problem to feature request**

A `ChangeSensitivity` method in the `OptionsManager` singleton.

Resolves #42.

**Solution or enhancement to problem**

With this, a `ChangeSensitivity` method is added within the `OptionsManager` singleton. Along with that, the church event has been further refined. `ChurchEvent.cs` now includes a trigger of the `NearingBreathing` class, as well as a private trigger for changing the player's sensitivity. 

**Dependencies to the feature request**

The `ChurchEvent.cs` and `NearingBreathing.cs` scripts must be attached to the same living game object for the church event to be successfully executed.

**Additional context**

``` c#
public void ChangeSensitivity(float VerticalAxis, float HorizontalAxis)
        {
            this._cinemachineVirtualCamera.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_VerticalAxis.m_MaxSpeed = VerticalAxis;
            this._cinemachineVirtualCamera.GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachinePOV>().m_HorizontalAxis.m_MaxSpeed = HorizontalAxis;
        }
```